### PR TITLE
Add workflow for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,24 @@
+on: [push]
+
+name: ARMv7 build
+
+jobs:
+  linux_arm7:
+    name: Linux ARMv7
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: armv7-unknown-linux-gnueabihf
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --target armv7-unknown-linux-gnueabihf --release
+      - uses: actions/upload-artifact@v2
+        with:
+          name: raspivid_mjpeg_streamer
+          path: target/armv7-unknown-linux-gnueabihf/release/raspivid_mjpeg_server


### PR DESCRIPTION
This PR adds an automatic ARMv7 build workflow using GitHub Actions. I think this can be useful for people who want to try out raspivid_mjpeg_server without having to setup the Rust toolchain and compile it manually.

Example workflow run: https://github.com/rolandsz/raspivid_mjpeg_server/runs/2378636733
Resulting artifact: https://github.com/rolandsz/raspivid_mjpeg_server/suites/2526801869/artifacts/54755035

You may also want to consider adding a link to the README via [nightly.link](nightly.link), which is capable of generating a permanent URL for the latest artifact in the repository.
For my fork this URL would be [https://nightly.link/rolandsz/raspivid_mjpeg_server/workflows/nightly/gh-actions/raspivid_mjpeg_streamer.zip](https://nightly.link/rolandsz/raspivid_mjpeg_server/workflows/nightly/gh-actions/raspivid_mjpeg_streamer.zip)